### PR TITLE
feat: Markdown processing

### DIFF
--- a/src2/markdown.test.ts
+++ b/src2/markdown.test.ts
@@ -1,0 +1,91 @@
+import { createMetadata, createHtml } from './markdown';
+
+it('<link> for CSS', () => {
+  const metadata = createMetadata('', '/blog/2022/04/', ['/style.css'], []);
+  const expected = {
+    link: [
+      [
+        { name: 'rel', value: 'stylesheet' },
+        { name: 'href', value: '../../../style.css' },
+      ],
+    ],
+  };
+  expect(metadata).toStrictEqual(expected);
+});
+
+it('<script> for JavaScript', () => {
+  const metadata = createMetadata('', '/blog/2022/03/', [], ['/app.js']);
+  const expected = {
+    script: [
+      [
+        { name: 'type', value: 'text/javascript' },
+        { name: 'src', value: '../../../app.js' },
+      ],
+    ],
+  };
+
+  expect(metadata).toStrictEqual(expected);
+});
+
+it('Markdown to HTML', () => {
+  const md = `---
+title: "Sample Page"
+---
+
+Text
+`;
+  const metadata = createMetadata(md, '/', [], []);
+  const html = createHtml(md, metadata);
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Sample Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <p>Text</p>
+  </body>
+</html>
+`;
+
+  expect(html).toBe(expected);
+});
+
+it('Markdown to HTML with template', () => {
+  const md = `---
+title: "Sample Page"
+date: "2022-04-18"
+---
+  
+Text
+`;
+  const metadata = createMetadata(md, '/', [], [], ['date']);
+  const template = `<article>
+<header><h1><%- site.title %></h1></header>
+<div><span class="date"><%- metadata.custom.date %></span></div>
+<%- html %>
+</article>`;
+  const site = { title: 'Sample Web Site' };
+  const html = createHtml(md, metadata, template, site);
+  const expected = `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Sample Page</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+  </head>
+  <body>
+    <article>
+<header><h1>Sample Web Site</h1></header>
+<div><span class="date">2022-04-18</span></div>
+
+<p>Text</p>
+
+</article>
+  </body>
+</html>
+`;
+
+  expect(html).toBe(expected);
+});

--- a/src2/markdown.ts
+++ b/src2/markdown.ts
@@ -1,0 +1,124 @@
+import path from 'node:path';
+import ejs from 'ejs';
+import { readMetadata, stringify, Metadata, Attribute } from '@vivliostyle/vfm';
+
+/**
+ * Placeholder that indicates a content part when processing HTML templates.
+ * The replacement target is specified directly under `<body>` in HTML.
+ */
+const BODY_HTML_PLACEHOLDER = '4bd5d00d-52a6-12c5-7ba7-3b7ac0b352e6';
+
+/**
+ * Create `<link>` metadata of VFM.
+ * @param baseDir - The directory of the HTML file on which the relative path is based.
+ * @param stylesheets - Path collection of CSS files referenced as relative paths from the page.
+ * @returns `<link>` metadata of VFM.
+ */
+const createStyleSheetsMetadata = (
+  baseDir: string,
+  stylesheets: string[],
+): Array<Array<Attribute>> => {
+  const result: Array<Array<Attribute>> = [];
+  for (const filePath of stylesheets) {
+    const dir = path.relative(baseDir, path.dirname(filePath));
+    const hrefPath = path.join(dir, path.basename(filePath));
+    const rel: Attribute = { name: 'rel', value: 'stylesheet' };
+    const href: Attribute = { name: 'href', value: hrefPath };
+    result.push([rel, href]);
+  }
+
+  return result;
+};
+
+/**
+ * Create `<script>` metadata of VFM.
+ * @param baseDir - The directory of the HTML file on which the relative path is based.
+ * @param scripts - Path collection of JavaScript files referenced as relative paths from the page.
+ * @returns `<script>` metadata of VFM.
+ */
+const createScriptsMetadata = (
+  baseDir: string,
+  scripts: string[],
+): Array<Array<Attribute>> => {
+  const result: Array<Array<Attribute>> = [];
+  for (const filePath of scripts) {
+    const dir = path.relative(baseDir, path.dirname(filePath));
+    const srcPath = path.join(dir, path.basename(filePath));
+    const type: Attribute = { name: 'type', value: 'text/javascript' };
+    const src: Attribute = { name: 'src', value: srcPath };
+    result.push([type, src]);
+  }
+
+  return result;
+};
+
+/**
+ * Create metadata of VFM.
+ * @param md - Markdown string.
+ * @param baseDir - The directory of the HTML file on which the relative path is based.
+ * @param styleSheets - Path collection of CSS files referenced as relative paths from the page.
+ * @param scripts - Path collection of JavaScript files referenced as relative paths from the page.
+ * @param customKeys - A collection of key names to be ignored by meta processing.
+ * @returns Metadata.
+ */
+export const createMetadata = (
+  md: string,
+  baseDir: string,
+  styleSheets: string[],
+  scripts: string[],
+  customKeys: string[] = [],
+): Metadata => {
+  const metadata = readMetadata(md, customKeys);
+
+  const linksMetadata = createStyleSheetsMetadata(baseDir, styleSheets);
+  if (0 < linksMetadata.length) {
+    if (metadata.link) {
+      metadata.link = [...metadata.link, ...linksMetadata];
+    } else {
+      metadata.link = linksMetadata;
+    }
+  }
+
+  const scriptsMetadata = createScriptsMetadata(baseDir, scripts);
+  if (0 < scriptsMetadata.length) {
+    if (metadata.script) {
+      metadata.script = [...metadata.script, ...scriptsMetadata];
+    } else {
+      metadata.script = scriptsMetadata;
+    }
+  }
+
+  return metadata;
+};
+
+/**
+ * Create HTML from Markdown and parameters.
+ *
+ * The following parameters are specified in the EJS `template`.
+ * - `metadata`: The `metadata` argument specified for this function.
+ * - `site`: The `site` argument specified for this function.
+ * - `html`: HTML created from Markdown text.
+ * @param md - Markdown string.
+ * @param metadata - Metadata of VFM.
+ * @param template - Template string of EJS.
+ * @param site - User data of the web site.
+ */
+export const createHtml = (
+  md: string,
+  metadata: Metadata,
+  template: string = '',
+  site: object = {},
+): string => {
+  if (template) {
+    const pageHtml = stringify(BODY_HTML_PLACEHOLDER, {}, metadata);
+    const bodyHtml = ejs.render(template, {
+      metadata,
+      site,
+      html: stringify(md, { partial: true }),
+    });
+
+    return pageHtml.replace(`<p>${BODY_HTML_PLACEHOLDER}</p>`, bodyHtml);
+  }
+
+  return stringify(md, {}, metadata);
+};


### PR DESCRIPTION
refs #2 

コールバックでページ生成するため、大幅な設計変更をする。既存とは別に `src2` へ段階的に実装してゆき、ひととおり動作確認できたら `src` と入れ替える予定。まずは Markdown 処理。既存との違いは以下。

- GatsbyJS の `gatsby-node.js` 風にするため、ファイルではなくメモリー上に HTML を生成する
  - ファイル出力の前にカスタマイズの余地を持たせるための設計
  - ファイル出力はコールバックから呼び出す `createPage` 関数から実行する予定
- HTML 生成においてメタデータと本文を分割
  - コールバックにもこれらは個別に指定される
  - コールバックでメタデータを変更すると `<body>` より上をカスタマイズできる
  - メタデータは EJS テンプレート側から `metadata` として参照可能
  - 本文は EJS テンプレート側から `html` として参照可能
  - `<body>` より上層はメタデータ、それ以下は EJS テンプレートでカスタマイズする

詳細はユニット テストを参照のこと。