### PR TITLE
feat: Create content

### DIFF
--- a/src2/content.test.ts
+++ b/src2/content.test.ts
@@ -1,0 +1,45 @@
+import { createDestFilePath, createContent, createContents } from './content';
+
+it('Create destination file path', () => {
+  const filePath = createDestFilePath(
+    '/src/pages/blog/sample.jpg',
+    '/src/pages',
+    '/public',
+  );
+  const expected = '/public/blog/sample.jpg';
+
+  expect(filePath).toBe(expected);
+});
+
+it('Create destination file path with extension name', () => {
+  const filePath = createDestFilePath(
+    '/src/pages/blog/sample.md',
+    '/src/pages',
+    '/public',
+    '.html',
+  );
+  const expected = '/public/blog/sample.html';
+
+  expect(filePath).toBe(expected);
+});
+
+it('Create content', async () => {
+  const content = await createContent(
+    'src2/data/pages/index.md',
+    'src2/data/pages',
+    'src2/data/public',
+    { customKeys: ['date'] },
+  );
+
+  expect(content.markdownFilePath).toBe('src2/data/pages/index.md');
+  expect(content.htmlFilePath).toBe('src2/data/public/index.html');
+  expect(content.metadata.title).toBe('My Web Site');
+  expect(content.metadata.custom!.date).toBe('2022-04-20');
+});
+
+it('Create multiple contents', async () => {
+  const contents = await createContents('src2/data/pages', 'src2/data/public', {
+    customKeys: ['date'],
+  });
+  expect(contents.length).toBe(2);
+});

--- a/src2/content.ts
+++ b/src2/content.ts
@@ -1,0 +1,154 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Metadata } from '@vivliostyle/vfm';
+import type { CreateMetadataOptions } from './markdown';
+import { createMetadata } from './markdown';
+
+/**
+ * Content of the page.
+ */
+export type Content = {
+  /**
+   * Path of the source Markdown file.
+   */
+  markdownFilePath: string;
+  /**
+   * Path of the destination HTML file.
+   */
+  htmlFilePath: string;
+  /**
+   * Metadata of the page.
+   */
+  metadata: Metadata;
+  /**
+   * Markdown of the page.
+   */
+  markdown: string;
+};
+
+/**
+ * Create the path of destination file.
+ * @param srcFilePath - Path of the source file.
+ * @param srcRootDir - Path of the source root directory.
+ * @param destDirPath - Path of the destination root directory.
+ * @param extname - Extension of the file to be changed. If not specified, the original extension will be used.
+ * @returns Path of the destination file.
+ */
+export const createDestFilePath = (
+  srcFilePath: string,
+  srcRootDir: string,
+  destDirPath: string,
+  extname?: string,
+) => {
+  const subPath = path.relative(srcRootDir, srcFilePath);
+  if (extname) {
+    return path.join(
+      destDirPath,
+      path.dirname(subPath),
+      `${path.basename(subPath, path.extname(subPath))}${extname}`,
+    );
+  } else {
+    return path.join(destDirPath, subPath);
+  }
+};
+
+/**
+ * Create content from the Markdown file.
+ * @param markdownFilePath - Path of the source Markdown file.
+ * @param pagesRootDir - Path of the source pages root directory.
+ * @param destRootDir - Path of the destination root directory.
+ * @param metadataOptions - Options of a metadata creation.
+ * @returns Content.
+ */
+export const createContent = async (
+  markdownFilePath: string,
+  pagesRootDir: string,
+  destRootDir: string,
+  metadataOptions?: CreateMetadataOptions,
+): Promise<Content> => {
+  const markdown = await fs.readFile(markdownFilePath, 'utf-8');
+  const htmlFilePath = createDestFilePath(
+    markdownFilePath,
+    pagesRootDir,
+    destRootDir,
+    '.html',
+  );
+
+  const metadata = createMetadata(
+    markdown,
+    path.dirname(htmlFilePath),
+    metadataOptions,
+  );
+
+  return {
+    markdownFilePath,
+    htmlFilePath,
+    metadata,
+    markdown,
+  };
+};
+
+/**
+ * Create content from the source directory and files.
+ * @param parentDir - Path of the parent source directory.
+ * @param pagesRootDir - Path of the source pages root directory.
+ * @param destRootDir - Path of the destination root directory.
+ * @param metadataOptions - Options of a metadata creation.
+ * @returns Contents
+ */
+const createContentsRecursive = async (
+  parentDir: string,
+  pagesRootDir: string,
+  destRootDir: string,
+  metadataOptions?: CreateMetadataOptions,
+): Promise<Content[]> => {
+  const items = await fs.readdir(parentDir);
+  let contents: Content[] = [];
+
+  for (let item of items) {
+    const itemPath = path.join(parentDir, item);
+    const stat = await fs.stat(itemPath);
+
+    if (stat.isDirectory()) {
+      const results = await createContentsRecursive(
+        itemPath,
+        pagesRootDir,
+        destRootDir,
+        metadataOptions,
+      );
+      contents = [...contents, ...results];
+    } else if (path.extname(item) === '.md') {
+      contents.push(
+        await createContent(
+          itemPath,
+          pagesRootDir,
+          destRootDir,
+          metadataOptions,
+        ),
+      );
+    } else {
+    }
+  }
+
+  return contents;
+};
+
+/**
+ * Create content from the source directory and files.
+ * @param pagesRootDir - Path of the source pages root directory.
+ * @param destRootDir - Path of the destination root directory.
+ * @param metadataOptions - Options of a metadata creation.
+ * @returns Contents
+ */
+export const createContents = async (
+  pagesRootDir: string,
+  destRootDir: string,
+  metadataOptions?: CreateMetadataOptions,
+): Promise<Content[]> => {
+  return createContentsRecursive(
+    pagesRootDir,
+    pagesRootDir,
+    destRootDir,
+    metadataOptions,
+  );
+};

--- a/src2/data/pages/blog/article.md
+++ b/src2/data/pages/blog/article.md
@@ -1,0 +1,9 @@
+---
+title: 'Blog Article'
+date: '2022-04-20'
+---
+
+The quick brown fox jumps over the lazy dog
+
+- item1
+- item2

--- a/src2/data/pages/index.md
+++ b/src2/data/pages/index.md
@@ -1,0 +1,9 @@
+---
+title: 'My Web Site'
+date: '2022-04-20'
+---
+
+The quick brown fox jumps over the lazy dog
+
+- item1
+- item2

--- a/src2/markdown.test.ts
+++ b/src2/markdown.test.ts
@@ -1,7 +1,9 @@
 import { createMetadata, createHtml } from './markdown';
 
 it('<link> for CSS', () => {
-  const metadata = createMetadata('', '/blog/2022/04/', ['/style.css'], []);
+  const metadata = createMetadata('', '/blog/2022/04/', {
+    styleSheets: ['/style.css'],
+  });
   const expected = {
     link: [
       [
@@ -14,7 +16,9 @@ it('<link> for CSS', () => {
 });
 
 it('<script> for JavaScript', () => {
-  const metadata = createMetadata('', '/blog/2022/03/', [], ['/app.js']);
+  const metadata = createMetadata('', '/blog/2022/03/', {
+    scripts: ['/app.js'],
+  });
   const expected = {
     script: [
       [
@@ -34,7 +38,7 @@ title: "Sample Page"
 
 Text
 `;
-  const metadata = createMetadata(md, '/', [], []);
+  const metadata = createMetadata(md, '/');
   const html = createHtml(md, metadata);
   const expected = `<!doctype html>
 <html>
@@ -60,7 +64,7 @@ date: "2022-04-18"
   
 Text
 `;
-  const metadata = createMetadata(md, '/', [], [], ['date']);
+  const metadata = createMetadata(md, '/', { customKeys: ['date'] });
   const template = `<article>
 <header><h1><%- site.title %></h1></header>
 <div><span class="date"><%- metadata.custom.date %></span></div>


### PR DESCRIPTION
refs #2

コンテンツ生成部分。

- ページ ディレクトリーを再帰的に走査して Markdown からコンテンツを生成
- Markdown 以外のファイルは現状と同様にコピーとする予定だが、リンクされてるものだけにするか迷っているため保留
- #2 の処理に絡めた watch を実現するため、HTML 生成とファイル出力は遅延している
- 生成されたコンテンツを `Array` として保持して...
  - コールバック関数上で加工してページ生成関数へ渡すことで HTML ファイルとして出力される
  - コンテンツに対象 Markdown ファイルのパスが保持されているため、watch 時に差分更新の基準とできる

ユニット テストでファイル読み込みが必要なため、`src2/data` を用意した。 テスト実装を併置する方式としているため、このようにしている。