### PR TITLE
chore: Refactoring createMetadata parameters

### DIFF
--- a/src2/content.ts
+++ b/src2/content.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { Metadata } from '@vivliostyle/vfm';
-import type { CreateMetadataOptions } from './markdown';
+import type { CreateMetadataOptions, CreateMetadataParams } from './markdown';
 import { createMetadata } from './markdown';
 
 /**
@@ -64,7 +64,7 @@ export const createContent = async (
   markdownFilePath: string,
   pagesRootDir: string,
   destRootDir: string,
-  metadataOptions?: CreateMetadataOptions,
+  metadataOptions: CreateMetadataOptions = {},
 ): Promise<Content> => {
   const markdown = await fs.readFile(markdownFilePath, 'utf-8');
   const htmlFilePath = createDestFilePath(
@@ -74,11 +74,14 @@ export const createContent = async (
     '.html',
   );
 
-  const metadata = createMetadata(
-    markdown,
-    path.dirname(htmlFilePath),
-    metadataOptions,
-  );
+  const metadataParams: CreateMetadataParams = {
+    baseDir: path.dirname(htmlFilePath),
+    styleSheets: metadataOptions.styleSheets || undefined,
+    scripts: metadataOptions.scripts || undefined,
+    customKeys: metadataOptions.customKeys || undefined,
+  };
+
+  const metadata = createMetadata(markdown, metadataParams);
 
   return {
     markdownFilePath,

--- a/src2/markdown.test.ts
+++ b/src2/markdown.test.ts
@@ -1,7 +1,8 @@
 import { createMetadata, createHtml } from './markdown';
 
 it('<link> for CSS', () => {
-  const metadata = createMetadata('', '/blog/2022/04/', {
+  const metadata = createMetadata('', {
+    baseDir: '/blog/2022/04/',
     styleSheets: ['/style.css'],
   });
   const expected = {
@@ -16,7 +17,8 @@ it('<link> for CSS', () => {
 });
 
 it('<script> for JavaScript', () => {
-  const metadata = createMetadata('', '/blog/2022/03/', {
+  const metadata = createMetadata('', {
+    baseDir: '/blog/2022/03/',
     scripts: ['/app.js'],
   });
   const expected = {
@@ -32,14 +34,14 @@ it('<script> for JavaScript', () => {
 });
 
 it('Markdown to HTML', () => {
-  const md = `---
+  const markdown = `---
 title: "Sample Page"
 ---
 
 Text
 `;
-  const metadata = createMetadata(md, '/');
-  const html = createHtml(md, metadata);
+  const metadata = createMetadata(markdown);
+  const html = createHtml(markdown, metadata);
   const expected = `<!doctype html>
 <html>
   <head>
@@ -64,7 +66,7 @@ date: "2022-04-18"
   
 Text
 `;
-  const metadata = createMetadata(md, '/', { customKeys: ['date'] });
+  const metadata = createMetadata(md, { customKeys: ['date'] });
   const template = `<article>
 <header><h1><%- site.title %></h1></header>
 <div><span class="date"><%- metadata.custom.date %></span></div>

--- a/src2/markdown.ts
+++ b/src2/markdown.ts
@@ -10,7 +10,7 @@ import { readMetadata, stringify } from '@vivliostyle/vfm';
 const BODY_HTML_PLACEHOLDER = '4bd5d00d-52a6-12c5-7ba7-3b7ac0b352e6';
 
 /**
- * Options of `createMetadata`.
+ * Options of the creation metadata..
  */
 export type CreateMetadataOptions = {
   /**
@@ -26,6 +26,16 @@ export type CreateMetadataOptions = {
    * Keys specified here are not processed as HTML tags, but are stored in `custom` in `Metadata`.
    */
   customKeys?: string[];
+};
+
+/**
+ * Parameters of `createMetadata`.
+ */
+export type CreateMetadataParams = CreateMetadataOptions & {
+  /**
+   * The directory of the HTML file on which the relative path is based.
+   */
+  baseDir?: string;
 };
 
 /**
@@ -76,35 +86,32 @@ const createScriptsMetadata = (
  * Create metadata of VFM.
  * @param markdown - Markdown string.
  * @param baseDir - The directory of the HTML file on which the relative path is based.
- * @param options - Options
+ * @param options - Options.
  * @returns Metadata.
  */
 export const createMetadata = (
   markdown: string,
-  baseDir: string,
   {
+    baseDir = undefined,
     styleSheets = [],
     scripts = [],
     customKeys = undefined,
-  }: CreateMetadataOptions = {},
+  }: CreateMetadataParams = {},
 ): Metadata => {
   const metadata = readMetadata(markdown, customKeys);
-
-  const linksMetadata = createStyleSheetsMetadata(baseDir, styleSheets);
-  if (0 < linksMetadata.length) {
-    if (metadata.link) {
-      metadata.link = [...metadata.link, ...linksMetadata];
-    } else {
-      metadata.link = linksMetadata;
+  if (baseDir) {
+    const linksMetadata = createStyleSheetsMetadata(baseDir, styleSheets);
+    if (0 < linksMetadata.length) {
+      metadata.link = metadata.link
+        ? [...metadata.link, ...linksMetadata]
+        : linksMetadata;
     }
-  }
 
-  const scriptsMetadata = createScriptsMetadata(baseDir, scripts);
-  if (0 < scriptsMetadata.length) {
-    if (metadata.script) {
-      metadata.script = [...metadata.script, ...scriptsMetadata];
-    } else {
-      metadata.script = scriptsMetadata;
+    const scriptsMetadata = createScriptsMetadata(baseDir, scripts);
+    if (0 < scriptsMetadata.length) {
+      metadata.script = metadata.script
+        ? [...metadata.script, ...scriptsMetadata]
+        : scriptsMetadata;
     }
   }
 


### PR DESCRIPTION
refs #2

The object is now combined with the unique parameters with those that are to be shared externally as types.

Expose the minimum required type as an option to be shared. As for createMetadata, there is processing that depends on baseDir, so this should also be included as a parameter.

`createMetadata` のパラメーターをリファクタリングした。`createContent` などを介して公開するものは従来どおりだが、オプションで相対パス処理の基準となるディレクトリーのパスに依存する `styleSheets` と `scripts` があり、これも含めて省略可能なパラメーターにしたかったので結合を利用して再設計した。

`createContent`  の呼び出し元としては相対パスの基準はその内部で決定するため、意識する必要はない。そのため必要採用のメタデータ生成用オプションとして `CreateMetadataOptions` を指定する。`createMetadata` は前述のように基準パス依存の関係上、それを含む必要があるのでオプションと結合された `CreateMetadataParams` を指定する。