### PR TITLE
feat: Implement callbacks for `createPages`

### DIFF
--- a/src2/data/vivliostyle.sitegen.func.js
+++ b/src2/data/vivliostyle.sitegen.func.js
@@ -1,0 +1,7 @@
+exports.createPages = ({ contents, createPage }) => {
+  contents.forEach((content) => {
+    createPage({ content, template: '', site: {} });
+  });
+
+  return contents;
+};

--- a/src2/page.test.ts
+++ b/src2/page.test.ts
@@ -1,0 +1,35 @@
+import { loadCreatePages } from './page';
+
+it('Load default function of createPages', () => {
+  const { isUserFunction } = loadCreatePages();
+  expect(isUserFunction).toBeFalsy();
+});
+
+it('Load user function of createPages', () => {
+  const { isUserFunction } = loadCreatePages(
+    'src2/data/vivliostyle.sitegen.func.js',
+  );
+  expect(isUserFunction).toBeTruthy();
+});
+
+it('createPages', () => {
+  let markdown = 'Sample';
+  const { createPages } = loadCreatePages();
+
+  createPages({
+    contents: [
+      {
+        markdown: 'Text',
+        markdownFilePath: '',
+        htmlFilePath: '',
+        metadata: {},
+      },
+    ],
+    createPage: ({ content }) => {
+      // Checks that data was properly passed to the callback
+      markdown = content.markdown;
+    },
+  });
+
+  expect(markdown).toBe('Text');
+});

--- a/src2/page.ts
+++ b/src2/page.ts
@@ -1,0 +1,110 @@
+import path from 'node:path';
+import { Content } from './content';
+
+/**
+ * Parameters for `CreatePage`.
+ */
+export type CreatePageParams = {
+  /**
+   * Content.
+   */
+  content: Content;
+  /**
+   * Template string of EJS.
+   */
+  template: string;
+  /**
+   * User data of the web site.
+   */
+  site: object;
+};
+
+/**
+ * Create page from content information.
+ * @param params - Parameters.
+ */
+export type CreatePage = (params: CreatePageParams) => void;
+
+/**
+ * Parameters for `CreatePages`.
+ */
+export type CreatePagesParams = {
+  /**
+   * Contents.
+   */
+  contents: Content[];
+  /**
+   * Function to create pages.
+   * Pages are output as HTML files by specifying data processed by a function implementing `CreatePages`.
+   */
+  createPage: CreatePage;
+};
+
+/**
+ * Create pages from content information.
+ * @param params - Parameters.
+ * @returns Collection of changed content. This will be reflected in the next processing.
+ */
+export type CreatePages = (params: CreatePagesParams) => Content[];
+
+/**
+ * Result values of `loadCreatePages`.
+ */
+export type LoadCreatePagesResult = {
+  /**
+   * Function that implements `CreatePages`.
+   */
+  createPages: CreatePages;
+  /**
+   * `true` if a user-defined function was loaded, `false` if it failed to load and is the default function.
+   */
+  isUserFunction: boolean;
+};
+
+/**
+ * Create pages from content information.
+ *
+ * This function is used if the user does not implement `createPages` based on `CreatePages`.
+ * @param params - Parameters.
+ * @returns Collection of changed content. This will be reflected in the next processing.
+ */
+const defaultCreatePages: CreatePages = (
+  params: CreatePagesParams,
+): Content[] => {
+  const { contents, createPage } = params;
+  contents.forEach((content) => {
+    createPage({ content, template: '', site: {} });
+  });
+
+  return contents;
+};
+
+/**
+ * Loads the `exports.createPages` function, which is the user's implementation of `CreatePages`.
+ * @param userScriptFilePath - Path to the JavaScript file where the user defined `exports.createPages`.
+ * @returns User implemented `CreatePages` function `exports.createPages`. If not found, default function in `vivliostyle-sitegen`.
+ */
+export const loadCreatePages = (
+  userScriptFilePath: string = '',
+): LoadCreatePagesResult => {
+  try {
+    const userExports = require(path.resolve(userScriptFilePath));
+    if (
+      userExports &&
+      userExports.createPages &&
+      typeof userExports.createPages === 'function'
+    ) {
+      return {
+        createPages: userExports.createPages as CreatePages,
+        isUserFunction: true,
+      };
+    }
+  } catch {
+    // Load failure returns the default function, so nothing is done.
+  }
+
+  return {
+    createPages: defaultCreatePages,
+    isUserFunction: false,
+  };
+};


### PR DESCRIPTION
refs #2 

ユーザー定義または既定の `createPages` コールバック処理を実装。

動的 `require` かつ対象に JavaScript を許可しているため、ユーザー実装コールバックの型チェックは最小限としている。このコールバック内から `createPage` に Markdown、メタデータ、テンプレート、ユーザー定義データを指定することで HTML 変換とファイル出力を実行する予定。

`createPage` もパラメーター化することでテスト用のモックを標準のコールバックとして記述できる。