### PR TITLE
feat: Re-implemented file copy functions

### DIFF
--- a/src2/assets.test.ts
+++ b/src2/assets.test.ts
@@ -1,0 +1,24 @@
+import { createDestFilePath } from './assets';
+
+it('Create destination file path', () => {
+  const filePath = createDestFilePath(
+    '/src/pages/blog/sample.jpg',
+    '/src/pages',
+    '/public',
+  );
+  const expected = '/public/blog/sample.jpg';
+
+  expect(filePath).toBe(expected);
+});
+
+it('Create destination file path with extension name', () => {
+  const filePath = createDestFilePath(
+    '/src/pages/blog/sample.md',
+    '/src/pages',
+    '/public',
+    '.html',
+  );
+  const expected = '/public/blog/sample.html';
+
+  expect(filePath).toBe(expected);
+});

--- a/src2/assets.ts
+++ b/src2/assets.ts
@@ -1,0 +1,116 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import fsAsync from 'node:fs/promises';
+
+/**
+ * Creates a directory with the specified path.
+ * - If the specified directory exists, it will not be created and will be successful.
+ * - If multiple non-existent hierarchies are specified, they are created recursively.
+ * @param dir - Path of the target directory.
+ * @returns `true` if successful or if the directory already exists, `false` otherwise.
+ */
+export const safeMkdir = (dir: string): boolean => {
+  if (fs.existsSync(dir)) {
+    return true;
+  }
+
+  fs.mkdirSync(dir, { recursive: true });
+  return fs.existsSync(dir);
+};
+
+/**
+ * Create the path of destination file.
+ * @param srcFile - Path of the source file.
+ * @param srcRootDir - Path of the source root directory.
+ * @param destRootDir - Path of the destination root directory.
+ * @param extname - Extension of the file to be changed. If not specified, the original extension will be used.
+ * @returns Path of the destination file.
+ */
+export const createDestFilePath = (
+  srcFile: string,
+  srcRootDir: string,
+  destRootDir: string,
+  extname?: string,
+): string => {
+  const subDir = path.relative(srcRootDir, srcFile);
+  if (extname) {
+    return path.join(
+      destRootDir,
+      path.dirname(subDir),
+      `${path.basename(subDir, path.extname(subDir))}${extname}`,
+    );
+  } else {
+    return path.join(destRootDir, subDir);
+  }
+};
+
+/**
+ * Copy the file.
+ * - If a file with the same name exists at the destination, it is overwritten.
+ * - If the destination directory hierarchy does not exist, it will be created.
+ * @param srcFile - Path of the source file.
+ * @param srcRootDir - Path of the source root directory.
+ * @param destRootDir - Path of the destination root directory.
+ * @returns Path of the destination file.
+ */
+export const copyFile = async (
+  srcFile: string,
+  srcRootDir: string,
+  destRootDir: string,
+): Promise<boolean> => {
+  try {
+    const destFile = createDestFilePath(srcFile, srcRootDir, destRootDir);
+    safeMkdir(path.dirname(destFile));
+    await fsAsync.copyFile(srcFile, destFile);
+
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Recursively copies files to the target directory, preserving the structure of the specified directory.
+ * @param srcDir - Path of the static resource directory.
+ * @param destDir - Path of the site destination directory.
+ * @returns Asynchronous task.
+ */
+const copyFilesRecursive = async (
+  srcDir: string,
+  destDir: string,
+): Promise<void> => {
+  safeMkdir(destDir);
+
+  const items = await fsAsync.readdir(srcDir);
+  for (let i = 0; i < items.length; ++i) {
+    const srcItemPath = path.join(srcDir, items[i]);
+    const stat = await fsAsync.stat(srcItemPath);
+    if (stat.isDirectory()) {
+      copyFilesRecursive(srcItemPath, path.join(destDir, items[i]));
+      continue;
+    }
+
+    await fsAsync.copyFile(srcItemPath, path.join(destDir, items[i]));
+  }
+};
+
+/**
+ * Copy the files from the static resource directory to the distribution directory.
+ * @param srcDir - Path of the static resource directory.
+ * @param destDir - Path of the site destination directory.
+ * @returns Asynchronous task.
+ */
+export const copyAssets = async (
+  srcDir: string,
+  destDir: string,
+): Promise<void> => {
+  try {
+    const stat = await fsAsync.stat(srcDir);
+    if (stat.isDirectory()) {
+      console.log(`[Assets] ${srcDir}`);
+      copyFilesRecursive(srcDir, destDir);
+    }
+  } catch (err) {
+    console.error(err);
+  }
+};

--- a/src2/content.test.ts
+++ b/src2/content.test.ts
@@ -1,27 +1,4 @@
-import { createDestFilePath, createContent, createContents } from './content';
-
-it('Create destination file path', () => {
-  const filePath = createDestFilePath(
-    '/src/pages/blog/sample.jpg',
-    '/src/pages',
-    '/public',
-  );
-  const expected = '/public/blog/sample.jpg';
-
-  expect(filePath).toBe(expected);
-});
-
-it('Create destination file path with extension name', () => {
-  const filePath = createDestFilePath(
-    '/src/pages/blog/sample.md',
-    '/src/pages',
-    '/public',
-    '.html',
-  );
-  const expected = '/public/blog/sample.html';
-
-  expect(filePath).toBe(expected);
-});
+import { createContent, createContents } from './content';
 
 it('Create content', async () => {
   const content = await createContent(

--- a/src2/content.ts
+++ b/src2/content.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { Metadata } from '@vivliostyle/vfm';
 import type { CreateMetadataOptions } from './markdown';
 import { createMetadata } from './markdown';
+import { createDestFilePath, copyFile } from './assets';
 
 /**
  * Content of the page.
@@ -24,32 +25,6 @@ export type Content = {
    * Markdown of the page.
    */
   markdown: string;
-};
-
-/**
- * Create the path of destination file.
- * @param srcFilePath - Path of the source file.
- * @param srcRootDir - Path of the source root directory.
- * @param destDirPath - Path of the destination root directory.
- * @param extname - Extension of the file to be changed. If not specified, the original extension will be used.
- * @returns Path of the destination file.
- */
-export const createDestFilePath = (
-  srcFilePath: string,
-  srcRootDir: string,
-  destDirPath: string,
-  extname?: string,
-) => {
-  const subPath = path.relative(srcRootDir, srcFilePath);
-  if (extname) {
-    return path.join(
-      destDirPath,
-      path.dirname(subPath),
-      `${path.basename(subPath, path.extname(subPath))}${extname}`,
-    );
-  } else {
-    return path.join(destDirPath, subPath);
-  }
 };
 
 /**
@@ -127,7 +102,7 @@ const createContentsRecursive = async (
         ),
       );
     } else {
-      // TODO: Copy file
+      await copyFile(itemPath, pagesRootDir, destRootDir);
     }
   }
 


### PR DESCRIPTION
refs #2 

既存の `assets.ts` を元にファイル、ディレクトリー、パス操作を集約して再実装。「静的リソースとしてのファイル = assets」を担当するものと位置づける。

最終的に `util.ts` は廃止して共通機能は `assets.ts` のように明確な役割へ属するものから参照する方針を徹底したい。