### PR TITLE
feat: Redesign configurations

### DIFF
--- a/src2/config.test.ts
+++ b/src2/config.test.ts
@@ -1,8 +1,14 @@
+import path from 'node:path';
+import type { Config } from './config';
 import { loadConfig } from './config';
 
 it('Loads user-defined configurations', () => {
-  const config = loadConfig('./src2/data');
-  const expected = {
+  const appRootDir = path.resolve('./src2/data/');
+  const config = loadConfig(path.join(appRootDir, 'vivliostyle.sitegen.js'));
+  const expected: Config = {
+    srcPagesDir: path.join(appRootDir, 'pages'),
+    srcAssetsDir: path.join(appRootDir, 'assets'),
+    destDir: path.join(appRootDir, 'public'),
     site: {
       title: 'Sample Site',
     },
@@ -15,17 +21,21 @@ it('Loads user-defined configurations', () => {
     customKeys: ['date', 'categories', 'tags'],
   };
 
-  expect(config.userConfig).toStrictEqual(expected);
+  expect(config).toStrictEqual(expected);
 });
 
 it('Failed to load user-defined configurations (default values)', () => {
   const config = loadConfig('');
+  const appRootDir = process.cwd();
   const expected = {
+    srcPagesDir: path.join(appRootDir, 'src', 'pages'),
+    srcAssetsDir: path.join(appRootDir, 'src', 'assets'),
+    destDir: path.join(appRootDir, 'public'),
     site: {},
     styleSheets: [],
     scripts: [],
     customKeys: [],
   };
 
-  expect(config.userConfig).toStrictEqual(expected);
+  expect(config).toStrictEqual(expected);
 });

--- a/src2/data/vivliostyle.sitegen.js
+++ b/src2/data/vivliostyle.sitegen.js
@@ -1,4 +1,7 @@
 module.exports = {
+  srcPagesDir: 'pages',
+  srcAssetsDir: 'assets',
+  destDir: 'public',
   site: {
     title: 'Sample Site',
   },


### PR DESCRIPTION
refs #2

Added the ability to specify the path to the configuration file.
Abstraction about file paths improves ease of design and testing.

設定ファイルのパスを外部指定にしてファイル名の知識を抽象化した。テストや CLI オプションなどで設定ファイルを動的に変更したくなる可能性を考慮した変更。