### PR TITLE
feat: Implemented the ability to transpile AltCSS to CSS

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,6 @@ module.exports = {
   verbose: true,
   testTimeout: 10000,
   transform: {
-    '^.+\\.ts$': 'ts-jest'
-  }
-}
+    '^.+\\.ts$': 'ts-jest',
+  },
+};

--- a/package.json
+++ b/package.json
@@ -37,20 +37,20 @@
   },
   "dependencies": {
     "@vivliostyle/vfm": "^1.2.1",
-    "browser-sync": "^2.27.7",
+    "browser-sync": "^2.27.10",
     "chokidar": "^3.5.3",
-    "commander": "^9.0.0",
-    "ejs": "^3.1.6",
-    "sass": "^1.49.0"
+    "commander": "^9.2.0",
+    "ejs": "^3.1.8",
+    "sass": "^1.52.0"
   },
   "devDependencies": {
     "@types/browser-sync": "^2.26.3",
-    "@types/ejs": "^3.1.0",
-    "@types/jest": "^27.4.0",
-    "@types/node": "^17.0.13",
+    "@types/ejs": "^3.1.1",
+    "@types/jest": "^27.5.1",
+    "@types/node": "^17.0.35",
     "@types/sass": "^1.43.1",
-    "jest": "^27.4.7",
-    "ts-jest": "^27.1.3",
-    "typescript": "^4.5.5"
+    "jest": "^28.1.0",
+    "ts-jest": "^28.0.2",
+    "typescript": "^4.6.4"
   }
 }

--- a/src2/config.test.ts
+++ b/src2/config.test.ts
@@ -19,6 +19,11 @@ it('Loads user-defined configurations', () => {
       'https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.0.1/mermaid.min.js',
     ],
     customKeys: ['date', 'categories', 'tags'],
+    css: {
+      type: 'sass',
+      src: 'scss/app.scss',
+      dest: 'app.css',
+    },
   };
 
   expect(config).toStrictEqual(expected);

--- a/src2/config.ts
+++ b/src2/config.ts
@@ -1,5 +1,25 @@
 import path from 'node:path';
 import fs from 'node:fs';
+import type { CssType } from './css';
+
+/**
+ * Configuration of the transpile AltCSS file to CSS.
+ */
+export type CssConfig = {
+  /**
+   * Type of CSS engine.
+   */
+  type: CssType;
+  /**
+   * Path of the AltCSS file.
+   */
+  src: string;
+  /**
+   * Path of the transpiled CSS file.
+   * Specify a path relative to the destination (site distribution) directory.
+   */
+  dest: string;
+};
 
 /**
  * Configuration of the vivliostyle-sitegen.
@@ -34,6 +54,10 @@ export type Config = {
    * Keys specified here are not processed as HTML tags, but are stored in `custom` in `Metadata`.
    */
   customKeys: string[];
+  /**
+   * Configuration for transpile CSS.
+   */
+  css?: CssConfig;
 };
 
 /**
@@ -54,6 +78,20 @@ const praseStringArray = (values: any): string[] => {
   }
 
   return result;
+};
+
+/**
+ * Check the CSS config.
+ * @param value - Value from user data.
+ * @returns Checked value. If the value is invalid, it is `undefined`.
+ */
+const checkCssConfig = (value: any): CssConfig | undefined => {
+  return typeof value === 'object' &&
+    typeof value.type === 'string' &&
+    typeof value.src === 'string' &&
+    typeof value.dest === 'string'
+    ? (value as CssConfig)
+    : undefined;
 };
 
 /**
@@ -117,6 +155,11 @@ export const loadConfig = (configFile: string): Config => {
     config.styleSheets = praseStringArray(userConfig.styleSheets);
     config.scripts = praseStringArray(userConfig.scripts);
     config.customKeys = praseStringArray(userConfig.customKeys);
+
+    const css = checkCssConfig(userConfig.css);
+    if (css) {
+      config.css = css;
+    }
   } catch {
     console.log('No configuration file exists, so default values are used.');
   }

--- a/src2/css.ts
+++ b/src2/css.ts
@@ -1,0 +1,63 @@
+import fs from 'node:fs';
+import sass from 'sass';
+
+/**
+ * Type of CSS engine.
+ */
+export type CssType = 'sass';
+
+/**
+ * Transpile Sass/SCSS file to CSS.
+ * @param src - Path of the Sass/SCSS file.
+ * @returns CSS string on success, empty string otherwise.
+ */
+const transpileSass = (src: string): string => {
+  try {
+    const result = sass.compile(src);
+    return result.css;
+  } catch (err) {
+    console.error(err);
+    return '';
+  }
+};
+
+/**
+ * Transpile AltCSS file to CSS.
+ * @param type - Type of CSS engine.
+ * @param src - Path of the AltCSS file.
+ * @returns CSS string on success, empty string otherwise.
+ */
+export const transpileCss = (type: CssType, src: string): string => {
+  switch (type) {
+    case 'sass':
+      return transpileSass(src);
+
+    default:
+      return '';
+  }
+};
+
+/**
+ * Transpile AltCSS to CSS and output to file.
+ * @param type - Type of CSS engine.
+ * @param src - Path of the AltCSS file.
+ * @param dest - Path of the destination CSS file..
+ * @returns CSS string on success, empty string otherwise.
+ */
+export const transpileCssWithSave = async (
+  type: CssType,
+  src: string,
+  dest: string,
+): Promise<boolean> => {
+  try {
+    const css = transpileCss(type, src);
+    if (css === '') {
+      return false;
+    }
+
+    await fs.promises.writeFile(dest, css);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src2/data/vivliostyle.sitegen.js
+++ b/src2/data/vivliostyle.sitegen.js
@@ -12,4 +12,9 @@ module.exports = {
     'https://cdnjs.cloudflare.com/ajax/libs/mermaid/9.0.1/mermaid.min.js',
   ],
   customKeys: ['date', 'categories', 'tags'],
+  css: {
+    type: 'sass',
+    src: 'scss/app.scss',
+    dest: 'app.css',
+  },
 };

--- a/src2/index.ts
+++ b/src2/index.ts
@@ -6,6 +6,7 @@ import type { CreatePage } from './page';
 import { loadCreatePages } from './page';
 import { createHtml } from './markdown';
 import { copyAssets, safeMkdir } from './assets';
+import { transpileCssWithSave } from './css';
 
 /**
  * Parameters for `generateStaticSite`.
@@ -53,6 +54,11 @@ export const generateStaticSite = async ({
 
   initDestDir(config.destDir);
   copyAssets(config.srcAssetsDir, config.destDir);
+
+  if (config.css) {
+    const css = config.css;
+    await transpileCssWithSave(css.type, css.src, css.dest);
+  }
 
   const contents = await createContents(
     config.srcPagesDir,


### PR DESCRIPTION
Designed with the possibility of supporting AltCSS other than Sass. For example, PostCSS and Stylus may be added.

refs #2 
Sass の Transpile を再実装。PostCSS や Stylus も追加する可能性がるため、ファイルや API 名は Sass や SCSS ではなく中立な CSS とした。なお dart-sass の以下の問題により Jest がエラーとなるためユニット テストを追加できなかった。

- [SASS fails to compile files under Jest · Issue #1692 · sass/dart-sass](https://github.com/sass/dart-sass/issues/1692#issuecomment-1128661723)