### PR TITLE
feat: Config paths should always be full paths

### DIFF
--- a/src2/config.test.ts
+++ b/src2/config.test.ts
@@ -21,8 +21,8 @@ it('Loads user-defined configurations', () => {
     customKeys: ['date', 'categories', 'tags'],
     css: {
       type: 'sass',
-      src: 'scss/app.scss',
-      dest: 'app.css',
+      src: path.join(appRootDir, 'scss', 'app.scss'),
+      dest: path.join(appRootDir, 'public', 'app.css'),
     },
   };
 

--- a/src2/config.ts
+++ b/src2/config.ts
@@ -158,6 +158,8 @@ export const loadConfig = (configFile: string): Config => {
 
     const css = checkCssConfig(userConfig.css);
     if (css) {
+      css.src = path.resolve(path.join(appRootDir, css.src));
+      css.dest = path.join(config.destDir, css.dest);
       config.css = css;
     }
   } catch {


### PR DESCRIPTION
This avoids problems associated with paths.

ツール内で参照されるパスは常に一箇所で絶対パスへ解決する。参照側は指定されたパスについて相対、絶対、それぞれの親階層などを意識する必要はなくそのまま処理すればよい。