### PR TITLE
chore: Added test for AltCSS transpile

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  testEnvironment: 'jest-environment-node-single-context',
   verbose: true,
   testTimeout: 10000,
   transform: {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^17.0.35",
     "@types/sass": "^1.43.1",
     "jest": "^28.1.0",
+    "jest-environment-node-single-context": "^28.0.0",
     "ts-jest": "^28.0.2",
     "typescript": "^4.6.4"
   }

--- a/src2/css.test.ts
+++ b/src2/css.test.ts
@@ -1,0 +1,13 @@
+import { transpileCss } from './css';
+
+it('Transpile SCSS', () => {
+  const css = transpileCss('sass', './src2/data/scss/app.scss');
+  const expected = `body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background-color: #fbfcfa;
+}`;
+  expect(css).toBe(expected);
+});

--- a/src2/data/scss/app.scss
+++ b/src2/data/scss/app.scss
@@ -1,0 +1,9 @@
+@use 'variables';
+
+body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background-color: variables.$color_page_back;
+}

--- a/src2/data/scss/variables.scss
+++ b/src2/data/scss/variables.scss
@@ -1,0 +1,25 @@
+$color_white: #ffffff;
+$color_black: #34495e;
+$color_black_dark: #2c3e50;
+$color_gray: #95a5a6;
+$color_gray_dark: #7f8c8d;
+$color_gray_darkness: #606b6c;
+$color_silver: #ecf0f1;
+$color_silver_dark: #bdc3c7;
+$color_red: #e74c3c;
+$color_red_dark: #c0392b;
+$color_purple: #9b59b6;
+$color_purple_dark: #8e44ad;
+$color_orange: #e67e22;
+$color_orange_dark: #d35400;
+$color_yellow: #f1c40f;
+$color_yellow_dark: #f39c12;
+$color_blue: #3498db;
+$color_blue_dark: #2980b9;
+$color_green: #2ecc71;
+$color_green_dark: #27ae60;
+$color_green2: #1abc9c;
+$color_green2_dark: #16a085;
+
+$color_page_back: #fbfcfa;
+$color_page_text: #34495e;


### PR DESCRIPTION
以下の Issue にて Jest 設定に `testEnvironment: 'jest-environment-node-single-context'` を追加する方法を提案していただいた。この方法を試したところ `sass.compile(path)` が正常に動作することを確認できたので PR する。

- [SASS fails to compile files under Jest · Issue #1692 · sass/dart-sass](https://github.com/sass/dart-sass/issues/1692)

なお `jest-environment-node-single-context` は npm として追加する必要あり。Jest 設定は `jest.config.js` と TypeScript 版 (`ts-node` が必要) である `jest.config.ts` のどちらでも動作した。

`testEnvironment` をチェックできそうなので TypeScript にしてみた。しかしこのプロパティーは `jest-environment-node-single-context` のように任意の npm を指定することがあるため `string` となっているため効果が薄い。また設定変更も稀なので `ts-jest` を必要としない JavaScript へ戻した。