### PR TITLE
feat: Relative to content path

### DIFF
--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -4,14 +4,24 @@ it('Create content', async () => {
   const content = await createContent(
     'src/data/pages/index.md',
     'src/data/pages',
-    'src/data/public',
     { customKeys: ['date'] },
   );
 
-  expect(content.markdownFilePath).toBe('src/data/pages/index.md');
-  expect(content.htmlFilePath).toBe('src/data/public/index.html');
+  expect(content.path).toBe('index.html');
   expect(content.metadata.title).toBe('My Web Site');
   expect(content.metadata.custom!.date).toBe('2022-04-20');
+});
+
+it('Create content of sub directories', async () => {
+  const content = await createContent(
+    'src/data/pages/blog/article.md',
+    'src/data/pages',
+    { customKeys: ['date'] },
+  );
+
+  expect(content.path).toBe('blog/article.html');
+  expect(content.metadata.title).toBe('Blog Article');
+  expect(content.metadata.custom!.date).toBe('2022-05-30');
 });
 
 it('Create multiple contents', async () => {

--- a/src/content.ts
+++ b/src/content.ts
@@ -10,13 +10,9 @@ import { createDestFilePath, copyFile } from './assets';
  */
 export type Content = {
   /**
-   * Path of the source Markdown file.
+   * Relation path of the HTML file in destination directory.
    */
-  markdownFilePath: string;
-  /**
-   * Path of the destination HTML file.
-   */
-  htmlFilePath: string;
+  path: string;
   /**
    * Metadata of the page.
    */
@@ -31,21 +27,19 @@ export type Content = {
  * Create content from the Markdown file.
  * @param markdownFilePath - Path of the source Markdown file.
  * @param pagesRootDir - Path of the source pages root directory.
- * @param destRootDir - Path of the destination root directory.
  * @param metadataOptions - Options of a metadata creation.
  * @returns Content.
  */
 export const createContent = async (
   markdownFilePath: string,
   pagesRootDir: string,
-  destRootDir: string,
   metadataOptions: CreateMetadataOptions = {},
 ): Promise<Content> => {
   const markdown = await fs.readFile(markdownFilePath, 'utf-8');
   const htmlFilePath = createDestFilePath(
     markdownFilePath,
     pagesRootDir,
-    destRootDir,
+    '',
     '.html',
   );
   const metadata = createMetadata(markdown, {
@@ -56,8 +50,7 @@ export const createContent = async (
   });
 
   return {
-    markdownFilePath,
-    htmlFilePath,
+    path: htmlFilePath,
     metadata,
     markdown,
   };
@@ -94,12 +87,7 @@ const createContentsRecursive = async (
       contents = [...contents, ...results];
     } else if (path.extname(item) === '.md') {
       contents.push(
-        await createContent(
-          itemPath,
-          pagesRootDir,
-          destRootDir,
-          metadataOptions,
-        ),
+        await createContent(itemPath, pagesRootDir, metadataOptions),
       );
     } else {
       await copyFile(itemPath, pagesRootDir, destRootDir);

--- a/src/data/pages/blog/article.md
+++ b/src/data/pages/blog/article.md
@@ -1,6 +1,6 @@
 ---
 title: 'Blog Article'
-date: '2022-04-20'
+date: '2022-05-30'
 ---
 
 The quick brown fox jumps over the lazy dog

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,15 +35,6 @@ const initDestDir = (dir: string): boolean => {
 };
 
 /**
- * Create page from content information.
- * @param params - Parameters.
- */
-const createPage: CreatePage = ({ content, template, site }): void => {
-  const html = createHtml(content.markdown, content.metadata, template, site);
-  fs.writeFileSync(content.htmlFilePath, html);
-};
-
-/**
  * Generate a static site from a Markdown and resource files.
  * @param params - Parameters.
  */
@@ -64,6 +55,16 @@ export const sitegen = async ({
   const { createPages } = loadCreatePages(
     path.join(appRootDir, 'vivliostyle.sitegen.func.js'),
   );
+
+  /**
+   * Create page from content information.
+   * Depends on `config.destDir` to output HTML files.
+   * @param params - Parameters.
+   */
+  const createPage: CreatePage = ({ content, template, site }): void => {
+    const html = createHtml(content.markdown, content.metadata, template, site);
+    fs.writeFileSync(path.join(config.destDir, content.path), html);
+  };
 
   const contents = createPages({
     contents: await createContents(config.srcPagesDir, config.destDir, config),

--- a/src/page.test.ts
+++ b/src/page.test.ts
@@ -20,8 +20,7 @@ it('createPages', () => {
     contents: [
       {
         markdown: 'Text',
-        markdownFilePath: '',
-        htmlFilePath: '',
+        path: '',
         metadata: {},
       },
     ],

--- a/src/watch.ts
+++ b/src/watch.ts
@@ -5,7 +5,7 @@ import type { Config, CssConfig } from './config';
 import type { Content } from './content';
 import type { CreatePage, CreatePages } from './page';
 import { transpileCssWithSave } from './css';
-import { copyFile, deleteFile } from './assets';
+import { copyFile, deleteFile, createDestFilePath } from './assets';
 import { createContent } from './content';
 
 /**
@@ -100,9 +100,7 @@ const addPageItem = async (
   }
 
   const contents = [...srcContents];
-  contents.push(
-    await createContent(filePath, config.srcPagesDir, config.destDir, config),
-  );
+  contents.push(await createContent(filePath, config.srcPagesDir, config));
   return createPages({ contents, createPage });
 };
 
@@ -128,13 +126,14 @@ const updatePageItem = async (
 
   const contents = [...srcContents];
   for (let i = 0; i < contents.length; ++i) {
-    if (filePath === contents[i].markdownFilePath) {
-      contents[i] = await createContent(
-        filePath,
-        config.srcPagesDir,
-        config.destDir,
-        config,
-      );
+    const htmlPath = createDestFilePath(
+      filePath,
+      config.srcPagesDir,
+      '',
+      '.html',
+    );
+    if (htmlPath === contents[i].path) {
+      contents[i] = await createContent(filePath, config.srcPagesDir, config);
       break;
     }
   }
@@ -164,7 +163,13 @@ const deletePageItem = async (
 
   const contents = [...srcContents];
   for (let i = 0; i < contents.length; ++i) {
-    if (filePath === contents[i].markdownFilePath) {
+    const htmlPath = createDestFilePath(
+      filePath,
+      config.srcPagesDir,
+      '',
+      '.html',
+    );
+    if (htmlPath === contents[i].path) {
       contents.splice(i, 1);
       break;
     }


### PR DESCRIPTION
Preparation for outputting pages that do not correspond to Markdown files, such as categories and tags.

refs #21 

`Content` のパスを Markdown/HTML のフルパスから HTML のみの相対パスに変更した。カテゴリーやタグなど Markdown を持たないページを `createPage` で生成するための布石。当初 Markdown ファイルのパスは watch モードで差分処理をする際の目安にしようと考えていたが、

- 出力先と 1:1 対応するならそちらのパスだけチェックすればよい
- 出力先の競合があれば更新と見なす
- 削除の場合でも Markdown ファイルのパスから相対パスを得られるので、それを元にキャッシュされたデータから対象を検索可能

ということで HTML ファイルの相対パスのみとする。将来 GatsbyJS のように Slug 対応する場合も同じ方式でゆける。メモリー的にもパスが 1 種類かつ相対になるので大幅に節約される。